### PR TITLE
メッセージ送信機能に関わるビューの訂正

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,4 +4,12 @@ class Group < ApplicationRecord
   has_many :messages
 
   validates :name, presence: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.body? ? last_message.body : '画像が投稿されています'
+    else
+      'まだメッセージはありません'
+    end
+  end
 end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -2,7 +2,7 @@
 .main-chat
   .chat-top
     .chat-top-group
-      chat
+      = @group.name
       %ul.chat-top-group__members
         Member : 
         %li.chat-top-group__members--detail

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -5,10 +5,9 @@
       = @group.name
       %ul.chat-top-group__members
         Member : 
-        %li.chat-top-group__members--detail
-          test1
-        %li.chat-top-group__members--detail
-          test2
+        - @group.users.each do |member|
+          %li.chat-top-group__members--detail
+            = member.name
     =link_to 'Edit', edit_group_path(@group), class: 'chat-top__edit-button'
   .chat-space
     %ul.chat-space__message

--- a/app/views/shared/_side-bar.html.haml
+++ b/app/views/shared/_side-bar.html.haml
@@ -13,4 +13,4 @@
           .side-group__link--name 
             = group.name
           .side-group__link--first-message 
-            まだメッセージがありません
+            = group.show_last_message


### PR DESCRIPTION
# WHAT
メッセージ送信機能に関わる、side_bar、main_chatのビューにおいて、グループ名やそのメンバー、最新のメッセージを反映させる

# WHY
今どのグループでチャットしているのか、グループでの最新の投稿は何かを可視化して、ユーザーの使い勝手をよくするため