### PR TITLE
チャット画面での写真の表示方法の修正

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -33,7 +33,14 @@ class ImageUploader < CarrierWave::Uploader::Base
   # version :thumb do
   #   process resize_to_fit: [800, 800]
   # end
-
+  process :fix_rotate
+  def fix_rotate
+    manipulate! do |img|
+        img = img.auto_orient
+        img = yield(img) if block_given?
+        img
+    end
+  end
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   # def extension_whitelist


### PR DESCRIPTION
# WHAT
チャット画面で、縦画像を送信しても、横に回転してしまうのを解消する

# WHY
写真の縦・横を判断して、綺麗にチャットのメッセージに表示したいから